### PR TITLE
[Feat/NST-40] #17 SharePresenter 작성

### DIFF
--- a/Noostak_iOS/Noostak_iOS/Global/Utility/SharePresenter.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Utility/SharePresenter.swift
@@ -1,0 +1,68 @@
+//
+//  SharePresenter.swift
+//  Noostak_iOS
+//
+//  Created by 박민서 on 1/8/25.
+//
+
+import UIKit
+import RxSwift
+
+final class SharePresenter {
+    
+    /// 공유 화면을 표시하는 함수
+    /// - Parameters:
+    ///   - items: 공유할 항목 (텍스트, 이미지, URL 등)
+    ///   - excludedActivityTypes: 제외할 Activity 타입
+    ///   - sourceViewController: 공유 화면을 띄울 뷰 컨트롤러
+    ///   - completion: 공유 완료/취소 콜백
+    static func share(
+        items: [Any],
+        excludedActivityTypes: [UIActivity.ActivityType]? = nil,
+        from sourceViewController: UIViewController,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) {
+        let activityViewController = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        activityViewController.excludedActivityTypes = excludedActivityTypes
+        
+        activityViewController.completionWithItemsHandler = { _, success, _, error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(success))
+            }
+        }
+        
+        sourceViewController.present(activityViewController, animated: true, completion: nil)
+    }
+}
+
+// MARK: Reactive Wrapping
+extension SharePresenter {
+    /// Reactive 확장 - 공유 화면 표시를 Observable로 반환
+    /// - Parameters:
+    ///   - items: 공유할 항목 (텍스트, 이미지, URL 등)
+    ///   - excludedActivityTypes: 제외할 Activity 타입
+    ///   - sourceViewController: 공유 화면을 띄울 뷰 컨트롤러
+    /// - Returns: 공유 성공 여부를 방출하는 Observable
+    static func share(
+        items: [Any],
+        excludedActivityTypes: [UIActivity.ActivityType]? = nil,
+        from sourceViewController: UIViewController
+    ) -> Observable<Bool> {
+        return Observable.create { observer in
+            share(items: items, excludedActivityTypes: excludedActivityTypes, from: sourceViewController) { result in
+                switch result {
+                    
+                case .success(let success):
+                    observer.onNext(success)
+                    observer.onCompleted()
+                    
+                case .failure(let error):
+                    observer.onError(error)
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🔥 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #17

<br/>

# 🔥 변경된 내용
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지를 써주세요 -->
- 공유 화면 표시하는 유틸리티를 작성했습니다.
<br/>

# 🔥 PR Point
<!-- 주요 코드를 써주세요 -->

코드는 아래와 같습니다. 아이폰 대상으로 하는 앱이므로, 아이패드 관련 설정은 제외했습니다.
1번 코드는 기본형으로, Result 타입 + completionHandler로 결과를 반환합니다.
2번 코드는 Rx 래핑형으로, onError로 에러를 처리하여 결과는 Bool 타입으로 반환합니다.
```swift
final class SharePresenter {
    /// 공유 화면을 표시하는 함수
    /// - Parameters:
    ///   - items: 공유할 항목 (텍스트, 이미지, URL 등)
    ///   - excludedActivityTypes: 제외할 Activity 타입
    ///   - sourceViewController: 공유 화면을 띄울 뷰 컨트롤러
    ///   - completion: 공유 완료/취소 콜백
    static func share(
        items: [Any],
        excludedActivityTypes: [UIActivity.ActivityType]? = nil,
        from sourceViewController: UIViewController,
        completion: @escaping (Result<Bool, Error>) -> Void
    )

    static func share(
            items: [Any],
            excludedActivityTypes: [UIActivity.ActivityType]? = nil,
            from sourceViewController: UIViewController
        ) -> Observable<Bool>
}
```

사용 예시는 다음과 같습니다.
```swift
SharePresenter.share(
    items: ["공유할 텍스트", UIImage(named: "exampleImage")!],
    excludedActivityTypes: [.postToFacebook, .postToTwitter],
    from: self
) { result in
    switch result {
    case .success(let success):
        if success {
            print("공유 성공")
        } else {
            print("공유 취소")
        }
    case .failure(let error):
        print("공유 실패: \(error.localizedDescription)")
    }
}

SharePresenter.share(
    items: ["공유할 텍스트", UIImage(named: "exampleImage")!],
    from: self
)
.subscribe(
    onNext: { result in
        switch result {
        case .success(let success):
            print(success ? "공유 성공" : "공유 취소")
        case .failure(let error):
            print("공유 실패: \(error.localizedDescription)")
        }
    },
    onError: { error in
        print("공유 실패: \(error.localizedDescription)")
    }
)
.disposed(by: disposeBag)
```

<br/>

# 🔥 Reference
https://fpraarnkk.atlassian.net/wiki/spaces/nstconfluence/pages/98946/Utility+SharePresenter
<br/>
