### PR TITLE
[Feat/NST-52] #20 - 일정 카테고리 버튼

### DIFF
--- a/Noostak_iOS/Noostak_iOS/Domain/Entity/Schedule.swift
+++ b/Noostak_iOS/Noostak_iOS/Domain/Entity/Schedule.swift
@@ -5,9 +5,9 @@
 //  Created by 오연서 on 1/5/25.
 //
 
-import Foundation
+import UIKit
 
-enum ScheduleCategory: String {
+enum ScheduleCategory: String, CaseIterable {
     case important
     case schedule
     case hobby
@@ -60,6 +60,20 @@ extension ScheduleCategory {
             return "취미"
         case .other:
             return "기타"
+        }
+    }
+    
+    /// 색상 반환
+    var displayColor: UIColor {
+        switch self {
+        case .important:
+            return .appOrange
+        case .schedule:
+            return .appBlue
+        case .hobby:
+            return .appPurple
+        case .other:
+            return .appMint
         }
     }
 }

--- a/Noostak_iOS/Noostak_iOS/Global/Components/MemberAvailabilityChip.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/MemberAvailabilityChip.swift
@@ -42,7 +42,7 @@ final class MemberAvailabilityChip: UIView {
     private func setUpUI() {
         
         self.do {
-            $0.layer.cornerRadius = 16
+            $0.layer.cornerRadius = 15
             $0.layer.borderWidth = 1
             
             switch status {
@@ -69,7 +69,7 @@ final class MemberAvailabilityChip: UIView {
     private func setUpLayout() {
         self.snp.makeConstraints {
             if status == .myself {
-                $0.width.equalTo(28)
+                $0.width.equalTo(39)
             }
             $0.height.equalTo(30)
         }

--- a/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
@@ -34,7 +34,6 @@ final class ScheduleCategoryButton: UIButton {
         switch categoryButtonType {
         case .Input:
             /// 입력 모드: 선택 여부에 따라 색상 변경
-            self.isUserInteractionEnabled = true
             self.titleLabel?.font = .PretendardStyle.b4_sb.font
             self.layer.borderWidth = 1
             self.layer.cornerRadius = 18.5

--- a/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
@@ -17,10 +17,11 @@ final class ScheduleCategoryButton: UIButton {
     private let isSelectedSubject = BehaviorRelay<Bool>(value: false)
         
     // MARK: Init
-    init(category: ScheduleCategory? = nil, buttonType: ButtonType = .Input) {
+    init(category: ScheduleCategory, buttonType: ButtonType) {
+        super.init(frame: .zero)
         self.category = category
         self.categoryButtonType = buttonType
-        super.init(frame: .zero)
+        self.setTitle(category.name, for: .normal)
         setUpUI()
         setUpLayout()
     }
@@ -74,15 +75,6 @@ final class ScheduleCategoryButton: UIButton {
                 self.setTitleColor(isSelected ? .appWhite : .appBlack, for: .normal)
             })
             .disposed(by: disposeBag)
-    }
-
-    /// 버튼 설정
-    func configure(for category: ScheduleCategory, buttonType: ButtonType) {
-        self.category = category
-        self.categoryButtonType = buttonType
-        self.setTitle(category.name, for: .normal)
-        setUpUI()
-        setUpLayout()
     }
 }
 

--- a/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
@@ -1,0 +1,94 @@
+//
+//  ScheduleCategoryButton.swift
+//  Noostak_iOS
+//
+//  Created by 오연서 on 1/8/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class ScheduleCategoryButton: UIButton {
+    // MARK: Properties
+    var category: ScheduleCategory?
+    var categoryButtonType: ButtonType = .Input
+    private let disposeBag = DisposeBag()
+    private let isSelectedSubject = BehaviorRelay<Bool>(value: false)
+        
+    // MARK: Init
+    init(category: ScheduleCategory? = nil, buttonType: ButtonType = .Input) {
+        self.category = category
+        self.categoryButtonType = buttonType
+        super.init(frame: .zero)
+        setUpUI()
+        setUpLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpUI() {
+        switch categoryButtonType {
+        case .Input:
+            /// 입력 모드: 선택 여부에 따라 색상 변경
+            self.isUserInteractionEnabled = true
+            self.titleLabel?.font = .PretendardStyle.b4_sb.font
+            self.layer.borderWidth = 1
+            self.layer.cornerRadius = 18.5
+            bindUI()
+        case .ReadOnly:
+            /// 표시 모드: 컬러 칩 스타일
+            guard let category = category else { return }
+            self.isUserInteractionEnabled = false
+            self.backgroundColor = category.displayColor
+            self.setTitleColor(category == .other ? .appGray800 : .appWhite, for: .normal)
+            self.layer.borderColor = UIColor.appWhite.cgColor
+            self.titleLabel?.font = .PretendardStyle.c2_sb.font
+            self.layer.borderWidth = 1
+            self.layer.cornerRadius = 15
+        }
+    }
+    
+    private func setUpLayout() {
+        self.snp.makeConstraints {
+            switch categoryButtonType {
+            case .Input:
+                $0.height.equalTo(37)
+                $0.width.equalTo(66)
+            case .ReadOnly:
+                $0.height.equalTo(30)
+                $0.width.equalTo(53)
+            }
+        }
+    }
+    
+    private func bindUI() {
+        isSelectedSubject
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] isSelected in
+                guard let self = self else { return }
+                self.backgroundColor = isSelected ? .appBlack : .appWhite
+                self.layer.borderColor = isSelected ? UIColor.appBlack.cgColor : UIColor.appGray200.cgColor
+                self.setTitleColor(isSelected ? .appWhite : .appBlack, for: .normal)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    /// 버튼 설정
+    func configure(for category: ScheduleCategory, buttonType: ButtonType) {
+        self.category = category
+        self.categoryButtonType = buttonType
+        self.setTitle(category.name, for: .normal)
+        setUpUI()
+        setUpLayout()
+    }
+}
+
+extension ScheduleCategoryButton {
+    enum ButtonType {
+        case Input
+        case ReadOnly
+    }
+}

--- a/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/ScheduleCategoryButton.swift
@@ -11,8 +11,8 @@ import RxCocoa
 
 final class ScheduleCategoryButton: UIButton {
     // MARK: Properties
-    var category: ScheduleCategory?
-    var categoryButtonType: ButtonType = .Input
+    private var category: ScheduleCategory?
+    private var categoryButtonType: ButtonType = .Input
     private let disposeBag = DisposeBag()
     private let isSelectedSubject = BehaviorRelay<Bool>(value: false)
         


### PR DESCRIPTION
# 🔥 Issue
close #20 

<br/>

# 🔥 PR Point
약속만들기 화면에서 다음과 같은 두 타입의 버튼을 개발했습니다.

- 정보입력-약속카테고리등록 화면에 이용되는 **Input type** 버튼
- 약속 등록확인 및 완료 화면에 이용되는 **ReadOnly type** 버튼

다음과 같이 사용하면 됩니다.

```swift
private let inputCategoryButtons: [ScheduleCategoryButton] = ScheduleCategory.allCases.map {
    let button = ScheduleCategoryButton(category: $0, buttonType: .Input)
    return button
}
    
private let categoryButton: ScheduleCategoryButton = {
    let button = ScheduleCategoryButton(category: .important, buttonType: .ReadOnly)
    return button
}()
```
얼른 스케쥴 피커놈 하고 싶어요..
많은 피드백 부탁드리옵니다 . . . 
<br/>

# 🔥 ScreenShot
<img src = "https://github.com/user-attachments/assets/a597f9c1-38e9-42e1-a4f6-7071f35c1d6c" width = "50%" height = "50%">

<br/>

