### PR TITLE
[Feat/NST-51] #25 Schedule picker 컴포넌트 작성

### DIFF
--- a/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePicker.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePicker.swift
@@ -1,0 +1,113 @@
+//
+//  SchedulePicker.swift
+//  Noostak_iOS
+//
+//  Created by 오연서 on 1/10/25.
+//
+
+import UIKit
+
+final class SchedulePicker: UICollectionView {
+    enum Mode {
+        case editMode
+        case readMode
+    }
+    
+    private let layout = SchedulePickerLayout()
+    private let timeHeaders: [String]
+    private let dateHeaders: [String]
+    private let mode: Mode
+    private var selectedCells: Set<IndexPath> = [] // edit Mode
+    private var cellAvailability: [IndexPath: Int] = [:] // read Mode
+
+    init(timeHeaders: [String], dateHeaders: [String], mode: Mode) {
+        self.timeHeaders = timeHeaders
+        self.dateHeaders = dateHeaders
+        self.mode = mode
+        super.init(frame: .zero, collectionViewLayout: layout)
+        self.layout.configure(totalRows: timeHeaders.count + 1, totalColumns: dateHeaders.count + 1)
+        self.register(SchedulePickerCell.self, forCellWithReuseIdentifier: SchedulePickerCell.identifier)
+        self.cellAvailability = calculateCellAvailability(totalRows: timeHeaders.count + 1,
+                                                          totalColumns: dateHeaders.count + 1,
+                                                          //Fix: mockMemberStartTime 변경 필요
+                                                          startTimes: mockMemberStartTime)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func addSelectedCell(at indexPath: IndexPath) {
+        guard mode == .editMode else { return }
+        if let cell = cellForItem(at: indexPath) as? SchedulePickerCell {
+            cell.isSelectedCell.toggle()
+            if cell.isSelectedCell {
+                selectedCells.insert(indexPath)
+            } else {
+                selectedCells.remove(indexPath)
+            }
+        }
+    }
+    
+    func configureCellBackground(_ cell: SchedulePickerCell, for indexPath: IndexPath, participants: Int) {
+        guard mode == .readMode else { return }
+        let count = cellAvailability[indexPath, default: 0]
+        let ratio = Float(count) / Float(participants)
+        
+        switch ratio {
+        case 0.01...0.2:
+            cell.backgroundColor = .appBlue50
+        case 0.2...0.4:
+            cell.backgroundColor = .appBlue200
+        case 0.4...0.6:
+            cell.backgroundColor = .appBlue400
+        case 0.6...0.8:
+            cell.backgroundColor = .appBlue700
+        case 0.8...1:
+            cell.backgroundColor = .appBlue800
+        default:
+            cell.backgroundColor = .clear
+        }
+    }
+}
+
+/// .ReadMode 색상 반환 로직
+extension SchedulePicker {
+    ///각 시간에 대한 가능 인원 계산
+    private func calculateCellAvailability(totalRows: Int, totalColumns: Int, startTimes: [String]) -> [IndexPath: Int] {
+        var cellAvailability: [IndexPath: Int] = [:]
+        let dateTimeMapping = createDateTimeMapping(totalRows: totalRows, totalColumns: totalColumns)
+        for startTime in startTimes {
+            if let indexPath = dateTimeMapping[startTime] {
+                cellAvailability[indexPath, default: 0] += 1
+            }
+        }
+        return cellAvailability
+    }
+    
+    /// 시각 - cell 매핑
+    private func createDateTimeMapping(totalRows: Int, totalColumns: Int) -> [String: IndexPath] {
+        var mapping: [String: IndexPath] = [:]
+        //FIX: mockDateList 변경 필요
+        let dates = mockDateList.map { String($0.prefix(10)) }
+        
+        for row in 1..<totalRows {
+            for column in 1..<totalColumns {
+                let time = self.timeHeaders[row - 1] // 시간
+                guard column - 1 < dates.count else { continue }
+                let date = dates[column - 1] // 날짜
+                let combinedKey = "\(date)T\(time):00:00"
+                let indexPath = IndexPath(item: (row * totalColumns) + column, section: 0)
+                mapping[combinedKey] = indexPath
+            }
+        }
+        return mapping
+    }
+
+    func reloadCellBackgrounds() {
+        self.cellAvailability = calculateCellAvailability(totalRows: self.timeHeaders.count + 1,
+                                                          totalColumns: self.dateHeaders.count + 1,
+                                                          startTimes: mockMemberStartTime)
+        self.reloadData()
+    }
+}

--- a/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerCell.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerCell.swift
@@ -1,0 +1,96 @@
+//
+//  SchedulePickerCell.swift
+//  Noostak_iOS
+//
+//  Created by 오연서 on 1/10/25.
+//
+
+import UIKit
+
+final class SchedulePickerCell: UICollectionViewCell {
+    
+    static let identifier = "SchedulePickerCell"
+    
+    private var textLabel = UILabel()
+    var isSelectedCell: Bool = false {
+        didSet {
+            backgroundColor = isSelectedCell ? .appBlue400 : .appWhite
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupCell()
+        setUpHierarchy()
+        setUpUI()
+        setUpLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpHierarchy() {
+        self.addSubview(textLabel)
+    }
+    
+    private func setUpUI() {
+        textLabel.do {
+            $0.font = .PretendardStyle.c4_r.font
+            $0.numberOfLines = 0
+            $0.textAlignment = .center
+            $0.textColor = .appGray600
+        }
+    }
+    
+    private func setUpLayout() {
+        textLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    private func setupCell() {
+        self.backgroundColor = .appWhite
+        self.layer.borderWidth = 0.5
+        self.layer.borderColor = UIColor.appGray200.cgColor
+    }
+    
+    func configureHeader(for indexPath: IndexPath, dateHeaders: [String], timeHeaders: [String]) {
+        let totalRows = timeHeaders.count + 1
+        let totalColumns = dateHeaders.count + 1
+        let row = indexPath.item / totalColumns
+        let column = indexPath.item % totalColumns
+        
+        let isTopLeft = indexPath.item == 0
+        let isTopRight = indexPath.item == totalColumns - 1
+        let isBottomLeft = indexPath.item == (totalRows - 1) * totalColumns
+        let isBottomRight = indexPath.item == totalRows * totalColumns - 1
+        
+        /// dateHeader, timeHeader text binding
+        if row == 0, column > 0 {
+            self.textLabel.text = dateHeaders[column - 1]
+        } else if column == 0, row > 0 {
+            self.textLabel.text = "\(timeHeaders[row - 1])시"
+        } else {
+            self.textLabel.text = ""
+        }
+        
+        /// 테이블 모서리 둥글게
+        if isTopLeft || isTopRight || isBottomLeft || isBottomRight {
+            self.layer.cornerRadius = 10
+            self.layer.masksToBounds = true
+            self.layer.borderColor = UIColor.appGray200.cgColor
+            if isTopLeft {
+                self.layer.maskedCorners = [.layerMinXMinYCorner]
+            } else if isTopRight {
+                self.layer.maskedCorners = [.layerMaxXMinYCorner]
+            } else if isBottomLeft {
+                self.layer.maskedCorners = [.layerMinXMaxYCorner]
+            } else if isBottomRight {
+                self.layer.maskedCorners = [.layerMaxXMaxYCorner]
+            }
+        } else {
+            self.layer.cornerRadius = 0
+        }
+    }
+}

--- a/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerCell.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerCell.swift
@@ -56,15 +56,9 @@ final class SchedulePickerCell: UICollectionViewCell {
     }
     
     func configureHeader(for indexPath: IndexPath, dateHeaders: [String], timeHeaders: [String]) {
-        let totalRows = timeHeaders.count + 1
         let totalColumns = dateHeaders.count + 1
         let row = indexPath.item / totalColumns
         let column = indexPath.item % totalColumns
-        
-        let isTopLeft = indexPath.item == 0
-        let isTopRight = indexPath.item == totalColumns - 1
-        let isBottomLeft = indexPath.item == (totalRows - 1) * totalColumns
-        let isBottomRight = indexPath.item == totalRows * totalColumns - 1
         
         /// dateHeader, timeHeader text binding
         if row == 0, column > 0 {
@@ -74,20 +68,31 @@ final class SchedulePickerCell: UICollectionViewCell {
         } else {
             self.textLabel.text = ""
         }
+    }
+    
+    func configureTableRoundness(for indexPath: IndexPath, dateHeaders: [String], timeHeaders: [String]) {
+        let totalRows = timeHeaders.count + 1
+        let totalColumns = dateHeaders.count + 1
         
-        /// 테이블 모서리 둥글게
+        let isTopLeft = indexPath.item == 0
+        let isTopRight = indexPath.item == totalColumns - 1
+        let isBottomLeft = indexPath.item == (totalRows - 1) * totalColumns
+        let isBottomRight = indexPath.item == totalRows * totalColumns - 1
+        
         if isTopLeft || isTopRight || isBottomLeft || isBottomRight {
             self.layer.cornerRadius = 10
             self.layer.masksToBounds = true
-            self.layer.borderColor = UIColor.appGray200.cgColor
-            if isTopLeft {
+            switch true {
+            case isTopLeft:
                 self.layer.maskedCorners = [.layerMinXMinYCorner]
-            } else if isTopRight {
+            case isTopRight:
                 self.layer.maskedCorners = [.layerMaxXMinYCorner]
-            } else if isBottomLeft {
+            case isBottomLeft:
                 self.layer.maskedCorners = [.layerMinXMaxYCorner]
-            } else if isBottomRight {
+            case isBottomRight:
                 self.layer.maskedCorners = [.layerMaxXMaxYCorner]
+            default:
+                break
             }
         } else {
             self.layer.cornerRadius = 0

--- a/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerLayout.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerLayout.swift
@@ -7,58 +7,59 @@
 
 import UIKit
 
-final class SchedulePickerLayout: UICollectionViewFlowLayout {
-    private let fixedFirstColumnWidth: CGFloat = 42
-    private let fixedFirstRowHeight: CGFloat = 36
-    
-    private var totalRows: Int = 0
-    private var totalColumns: Int = 0
-    private let minimumSpacing: CGFloat = 0
-    
-    func configure(totalRows: Int = 0, totalColumns: Int = 0) {
-        self.totalRows = totalRows
-        self.totalColumns = totalColumns
-        invalidateLayout()
-    }
-    
-    override func prepare() {
-        super.prepare()
-        guard let collectionView = collectionView else { return }
-        let remainingWidth = collectionView.bounds.width - fixedFirstColumnWidth - CGFloat(totalColumns - 1) * minimumSpacing
-        let dynamicColumnWidth = remainingWidth / CGFloat(totalColumns - 1)
-        let dynamicRowHeight = 32.0
+extension SchedulePicker {
+    final class SchedulePickerLayout: UICollectionViewFlowLayout {
+        private let fixedFirstColumnWidth: CGFloat = 42
+        private let fixedFirstRowHeight: CGFloat = 36
         
-        itemSize = CGSize(width: dynamicColumnWidth, height: dynamicRowHeight)
-        minimumLineSpacing = 0
-        minimumInteritemSpacing = 0
-        sectionInset = .zero
-    }
-    
-    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        let attributes = super.layoutAttributesForElements(in: rect)
-        attributes?.forEach { layoutAttribute in
-            let indexPath = layoutAttribute.indexPath
-            let column = indexPath.item % totalColumns
-            let row = indexPath.item / totalColumns
-            
-            // 첫 번째 열의 너비 고정, 열 간 간격 조정
-            if column == 0 {
-                layoutAttribute.frame.size.width = fixedFirstColumnWidth
-                layoutAttribute.frame.origin.x = 0
-            } else { // 두 번째 열 이후
-                let previousColumnRight = fixedFirstColumnWidth + CGFloat(column - 1) * (itemSize.width + minimumInteritemSpacing)
-                layoutAttribute.frame.origin.x = previousColumnRight
-            }
-            
-            // 첫 번째 행의 높이 고정, 행 간 간격 조정
-            if indexPath.item < totalColumns {
-                layoutAttribute.frame.size.height = fixedFirstRowHeight
-                layoutAttribute.frame.origin.y = 0
-            } else { // 두 번째 행 이후
-                let previousRowBottom = fixedFirstRowHeight + CGFloat(row - 1) * (itemSize.height + minimumLineSpacing)
-                layoutAttribute.frame.origin.y = previousRowBottom
-            }
+        private var totalRows: Int = 0
+        private var totalColumns: Int = 0
+        private let minimumSpacing: CGFloat = 0
+        
+        func configure(totalRows: Int = 0, totalColumns: Int = 0) {
+            self.totalRows = totalRows
+            self.totalColumns = totalColumns
         }
-        return attributes
+        
+        override func prepare() {
+            super.prepare()
+            guard let collectionView = collectionView else { return }
+            let remainingWidth = collectionView.bounds.width - fixedFirstColumnWidth - CGFloat(totalColumns - 1) * minimumSpacing
+            let dynamicColumnWidth = remainingWidth / CGFloat(totalColumns - 1)
+            let dynamicRowHeight = 32.0
+            
+            itemSize = CGSize(width: dynamicColumnWidth, height: dynamicRowHeight)
+            minimumLineSpacing = 0
+            minimumInteritemSpacing = 0
+            sectionInset = .zero
+        }
+        
+        override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+            let attributes = super.layoutAttributesForElements(in: rect)
+            attributes?.forEach { layoutAttribute in
+                let indexPath = layoutAttribute.indexPath
+                let column = indexPath.item % totalColumns
+                let row = indexPath.item / totalColumns
+                
+                // 첫 번째 열의 너비 고정, 열 간 간격 조정
+                if column == 0 {
+                    layoutAttribute.frame.size.width = fixedFirstColumnWidth
+                    layoutAttribute.frame.origin.x = 0
+                } else { // 두 번째 열 이후
+                    let previousColumnRight = fixedFirstColumnWidth + CGFloat(column - 1) * (itemSize.width + minimumInteritemSpacing)
+                    layoutAttribute.frame.origin.x = previousColumnRight
+                }
+                
+                // 첫 번째 행의 높이 고정, 행 간 간격 조정
+                if indexPath.item < totalColumns {
+                    layoutAttribute.frame.size.height = fixedFirstRowHeight
+                    layoutAttribute.frame.origin.y = 0
+                } else { // 두 번째 행 이후
+                    let previousRowBottom = fixedFirstRowHeight + CGFloat(row - 1) * (itemSize.height + minimumLineSpacing)
+                    layoutAttribute.frame.origin.y = previousRowBottom
+                }
+            }
+            return attributes
+        }
     }
 }

--- a/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerLayout.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Components/SchedulePicker/SchedulePickerLayout.swift
@@ -1,0 +1,64 @@
+//
+//  SchedulePickerLayout.swift
+//  Noostak_iOS
+//
+//  Created by 오연서 on 1/10/25.
+//
+
+import UIKit
+
+final class SchedulePickerLayout: UICollectionViewFlowLayout {
+    private let fixedFirstColumnWidth: CGFloat = 42
+    private let fixedFirstRowHeight: CGFloat = 36
+    
+    private var totalRows: Int = 0
+    private var totalColumns: Int = 0
+    private let minimumSpacing: CGFloat = 0
+    
+    func configure(totalRows: Int = 0, totalColumns: Int = 0) {
+        self.totalRows = totalRows
+        self.totalColumns = totalColumns
+        invalidateLayout()
+    }
+    
+    override func prepare() {
+        super.prepare()
+        guard let collectionView = collectionView else { return }
+        let remainingWidth = collectionView.bounds.width - fixedFirstColumnWidth - CGFloat(totalColumns - 1) * minimumSpacing
+        let dynamicColumnWidth = remainingWidth / CGFloat(totalColumns - 1)
+        let dynamicRowHeight = 32.0
+        
+        itemSize = CGSize(width: dynamicColumnWidth, height: dynamicRowHeight)
+        minimumLineSpacing = 0
+        minimumInteritemSpacing = 0
+        sectionInset = .zero
+    }
+    
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        let attributes = super.layoutAttributesForElements(in: rect)
+        attributes?.forEach { layoutAttribute in
+            let indexPath = layoutAttribute.indexPath
+            let column = indexPath.item % totalColumns
+            let row = indexPath.item / totalColumns
+            
+            // 첫 번째 열의 너비 고정, 열 간 간격 조정
+            if column == 0 {
+                layoutAttribute.frame.size.width = fixedFirstColumnWidth
+                layoutAttribute.frame.origin.x = 0
+            } else { // 두 번째 열 이후
+                let previousColumnRight = fixedFirstColumnWidth + CGFloat(column - 1) * (itemSize.width + minimumInteritemSpacing)
+                layoutAttribute.frame.origin.x = previousColumnRight
+            }
+            
+            // 첫 번째 행의 높이 고정, 행 간 간격 조정
+            if indexPath.item < totalColumns {
+                layoutAttribute.frame.size.height = fixedFirstRowHeight
+                layoutAttribute.frame.origin.y = 0
+            } else { // 두 번째 행 이후
+                let previousRowBottom = fixedFirstRowHeight + CGFloat(row - 1) * (itemSize.height + minimumLineSpacing)
+                layoutAttribute.frame.origin.y = previousRowBottom
+            }
+        }
+        return attributes
+    }
+}

--- a/Noostak_iOS/Noostak_iOS/Global/Utils/NSTDateUtility.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Utils/NSTDateUtility.swift
@@ -47,13 +47,18 @@ public final class NSTDateUtility {
 
 public extension NSTDateUtility {
     enum NSTDateFormatter {
+        case yyyyMMddTHHmmss
         case yyyyMMddHHmmss
         case yyyyMMdd
         case yyyyMM
         case EE
+        case HH
+        case MMddEE
         
         var format: String {
             switch self {
+            case .yyyyMMddTHHmmss:
+                return "yyyy-MM-dd'T'HH:mm:ss"
             case .yyyyMMddHHmmss:
                 return "yyyy-MM-dd HH:mm:ss"
             case .yyyyMMdd:
@@ -62,6 +67,10 @@ public extension NSTDateUtility {
                 return "yyyy-MM"
             case .EE:
                 return "EE"
+            case .HH:
+                return "HH"
+            case .MMddEE:
+                return "EE\nMM/dd"
             }
         }
     }
@@ -76,4 +85,43 @@ public extension NSTDateUtility {
             }
         }
     }
+}
+
+func dateList(_ dateStrings: [String]) -> [String] {
+    let formatter = NSTDateUtility(format: .yyyyMMddTHHmmss) // ISO 8601 형식
+    let displayFormatter = NSTDateUtility(format: .MMddEE) // 출력 형식
+    
+    return dateStrings.compactMap { dateString in
+        switch formatter.date(from: dateString) {
+        case .success(let date):
+            return displayFormatter.string(from: date)
+        case .failure(let error):
+            print("Failed to parse date \(dateString): \(error.localizedDescription)")
+            return nil
+        }
+    }
+}
+
+func timeList(_ startTime: String, _ endTime: String) -> [String] {
+    let formatter = NSTDateUtility(format: .yyyyMMddTHHmmss) // ISO 8601 형식
+    var result: [String] = []
+    
+    switch (formatter.date(from: startTime), formatter.date(from: endTime)) {
+    case (.success(let start), .success(let end)):
+        let calendar = Calendar.current
+        var current = start
+        
+        while current <= end {
+            result.append(NSTDateUtility(format: .HH).string(from: current)) // 출력 형식
+            if let nextHour = calendar.date(byAdding: .hour, value: 1, to: current) {
+                current = nextHour
+            } else {
+                break
+            }
+        }
+    default:
+        print("Failed to parse start or end time.")
+        return []
+    }
+    return result
 }

--- a/Noostak_iOS/Noostak_iOS/Global/Utils/NSTDateUtility.swift
+++ b/Noostak_iOS/Noostak_iOS/Global/Utils/NSTDateUtility.swift
@@ -87,41 +87,43 @@ public extension NSTDateUtility {
     }
 }
 
-func dateList(_ dateStrings: [String]) -> [String] {
-    let formatter = NSTDateUtility(format: .yyyyMMddTHHmmss) // ISO 8601 형식
-    let displayFormatter = NSTDateUtility(format: .MMddEE) // 출력 형식
-    
-    return dateStrings.compactMap { dateString in
-        switch formatter.date(from: dateString) {
-        case .success(let date):
-            return displayFormatter.string(from: date)
-        case .failure(let error):
-            print("Failed to parse date \(dateString): \(error.localizedDescription)")
-            return nil
-        }
-    }
-}
-
-func timeList(_ startTime: String, _ endTime: String) -> [String] {
-    let formatter = NSTDateUtility(format: .yyyyMMddTHHmmss) // ISO 8601 형식
-    var result: [String] = []
-    
-    switch (formatter.date(from: startTime), formatter.date(from: endTime)) {
-    case (.success(let start), .success(let end)):
-        let calendar = Calendar.current
-        var current = start
+extension NSTDateUtility {
+    static func dateList(_ dateStrings: [String]) -> [String] {
+        let formatter = NSTDateUtility(format: .yyyyMMddTHHmmss) // ISO 8601 형식
+        let displayFormatter = NSTDateUtility(format: .MMddEE) // 출력 형식
         
-        while current <= end {
-            result.append(NSTDateUtility(format: .HH).string(from: current)) // 출력 형식
-            if let nextHour = calendar.date(byAdding: .hour, value: 1, to: current) {
-                current = nextHour
-            } else {
-                break
+        return dateStrings.compactMap { dateString in
+            switch formatter.date(from: dateString) {
+            case .success(let date):
+                return displayFormatter.string(from: date)
+            case .failure(let error):
+                print("Failed to parse date \(dateString): \(error.localizedDescription)")
+                return nil
             }
         }
-    default:
-        print("Failed to parse start or end time.")
-        return []
     }
-    return result
+
+    static func timeList(_ startTime: String, _ endTime: String) -> [String] {
+        let formatter = NSTDateUtility(format: .yyyyMMddTHHmmss) // ISO 8601 형식
+        var result: [String] = []
+        
+        switch (formatter.date(from: startTime), formatter.date(from: endTime)) {
+        case (.success(let start), .success(let end)):
+            let calendar = Calendar.current
+            var current = start
+            
+            while current <= end {
+                result.append(NSTDateUtility(format: .HH).string(from: current)) // 출력 형식
+                if let nextHour = calendar.date(byAdding: .hour, value: 1, to: current) {
+                    current = nextHour
+                } else {
+                    break
+                }
+            }
+        default:
+            print("Failed to parse start or end time.")
+            return []
+        }
+        return result
+    }
 }


### PR DESCRIPTION
# 🔥 Issue
close #25 

<br/>

# 🔥 변경된 내용
NSTDateUtility 파일에 스케쥴피커에 필요한 케이스 및 함수 추가했습니다.

<br/>

# 🔥 PR Point
<!-- 주요 코드를 써주세요 -->
1. dateList와 timeList 함수로 스케쥴 표를 생성하기 위한 배열을 생성합니다.
```swift
let dateHeaders: [String] = dateList(mockDateList)
let timeHeaders: [String] = timeList(mockStartTime, mockEndTime)
```
2. Schedule Picker를 생성 후 dataSource에서 표의 가로, 세로 헤더에 내용을 채운 후 (readMode의 경우) 참가자 수에 따른 cell background를 조정하는 구조입니당
```swift
private lazy var schedulePicker = SchedulePicker(timeHeaders: timeHeaders, dateHeaders: dateHeaders, mode: .readMode)

cell.configureHeader(for: indexPath, dateHeaders: dateHeaders, timeHeaders: timeHeaders)
self.schedulePicker.configureCellBackground(cell, for: indexPath, participants: participants)

```

<br/>

# 🔥 ScreenShot
- read mode
<img src = "https://github.com/user-attachments/assets/6567f10d-9187-49f8-bad1-af6f05caf00d" width = "50%" height = "50%">


- edit mode
<img src = "https://github.com/user-attachments/assets/50309d3a-e9fa-49ef-8e49-68a656e5b353" width = "50%" height = "50%">
